### PR TITLE
Update readme instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -66,6 +66,8 @@ import (
 func Handle(evt json.RawMessage, ctx *runtime.Context) (interface{}, error) {
 	return "Hello, World!", nil
 }
+
+func main(){}
 ```
 
 [<img src="_asset/misc_arrow-up.png" align="right">](#top)


### PR DESCRIPTION
Having a main function is necessary to build the go binary as the compiler will look for it.

If you follow the step by step instructions to get the hello world lambda
working you get a build error -

```
can't load package: package . :
main.go:1:1: expected 'package', found 'EOF'
make: *** [_all] Error 1
make: *** [all] Error 2 
```

By adding an empty main function you can get rid of this error.